### PR TITLE
Remove xml onClick attributes from checkboxes.

### DIFF
--- a/PHC-Android/PHC/src/main/res/layout/fragment_account_registration.xml
+++ b/PHC-Android/PHC/src/main/res/layout/fragment_account_registration.xml
@@ -243,14 +243,12 @@
             <CheckBox android:id="@+id/checkbox_foster"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/prompt_foster"
-                android:onClick="onCheckboxClicked"/>
+                android:text="@string/prompt_foster"/>
 
             <CheckBox android:id="@+id/checkbox_military"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/prompt_military"
-                android:onClick="onCheckboxClicked"/>
+                android:text="@string/prompt_military"/>
 
         </LinearLayout>
 

--- a/PHC-Android/PHC/src/main/res/layout/fragment_event_registration.xml
+++ b/PHC-Android/PHC/src/main/res/layout/fragment_event_registration.xml
@@ -36,8 +36,7 @@
                 <CheckBox android:id="@+id/checkbox_homeless"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/prompt_homeless"
-                    android:onClick="onCheckboxClicked"/>
+                    android:text="@string/prompt_homeless"/>
 
                 <LinearLayout
                     android:id="@+id/children_layout"
@@ -49,8 +48,7 @@
                     <CheckBox android:id="@+id/checkbox_children"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/prompt_children"
-                        android:onClick="onCheckboxClicked"/>
+                        android:text="@string/prompt_children"/>
 
                 </LinearLayout>
 
@@ -64,8 +62,7 @@
                     <CheckBox android:id="@+id/checkbox_doctor"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/prompt_doctor"
-                        android:onClick="onCheckboxClicked"/>
+                        android:text="@string/prompt_doctor"/>
 
                 </LinearLayout>
 


### PR DESCRIPTION
Remove onClick attributes in the xml for account registration and event registration checkboxes. They were causing an error because no onClickListener method is implemented in the RegisterActivity.
