### PR TITLE
Byron/fix color

### DIFF
--- a/PHC-Android/PHC/src/main/java/phc/android/MainActivity.java
+++ b/PHC-Android/PHC/src/main/java/phc/android/MainActivity.java
@@ -114,6 +114,7 @@ public class MainActivity extends Activity
             setContentView(R.layout.activity_main);
         }
         mContext = this;
+
         super.onCreate(savedInstanceState);
     }
 
@@ -180,15 +181,15 @@ public class MainActivity extends Activity
          */
         if (servicesButton == null) { return; }
 
-        servicesButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-        servicesButton.setBackgroundResource(R.drawable.enabled_button);
-//        if (enabled) {
-//            servicesButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-//            servicesButton.setBackgroundResource(R.drawable.enabled_button);
-//        } else {
-//            servicesButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
-//            servicesButton.setBackgroundResource(R.drawable.disabled_button);
-//        }
+//        servicesButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+//        servicesButton.setBackgroundResource(R.drawable.enabled_button);
+        if (enabled) {
+            servicesButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+            servicesButton.setBackgroundResource(R.drawable.enabled_button);
+        } else {
+            servicesButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
+            servicesButton.setBackgroundResource(R.drawable.disabled_button);
+        }
     }
 
     /**
@@ -205,15 +206,15 @@ public class MainActivity extends Activity
          */
         if (registerButton == null) { return; }
 
-        registerButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-        registerButton.setBackgroundResource(R.drawable.enabled_button);
-//        if (enabled) {
-//            registerButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-//            registerButton.setBackgroundResource(R.drawable.enabled_button);
-//        } else {
-//            registerButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
-//            registerButton.setBackgroundResource(R.drawable.disabled_button);
-//        }
+//        registerButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+//        registerButton.setBackgroundResource(R.drawable.enabled_button);
+        if (enabled) {
+            registerButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+            registerButton.setBackgroundResource(R.drawable.enabled_button);
+        } else {
+            registerButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
+            registerButton.setBackgroundResource(R.drawable.disabled_button);
+        }
     }
 
     /**
@@ -230,15 +231,15 @@ public class MainActivity extends Activity
          */
         if (exitButton == null) { return; }
 
-        exitButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-        exitButton.setBackgroundResource(R.drawable.enabled_button);
-//        if (enabled) {
-//            exitButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
-//            exitButton.setBackgroundResource(R.drawable.enabled_button);
-//        } else {
-//            exitButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
-//            exitButton.setBackgroundResource(R.drawable.disabled_button);
-//        }
+//        exitButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+//        exitButton.setBackgroundResource(R.drawable.enabled_button);
+        if (enabled) {
+            exitButton.setTextAppearance(getApplicationContext(), R.style.EnabledButtonText);
+            exitButton.setBackgroundResource(R.drawable.enabled_button);
+        } else {
+            exitButton.setTextAppearance(getApplicationContext(), R.style.DisabledButtonText);
+            exitButton.setBackgroundResource(R.drawable.disabled_button);
+        }
     }
 
     private void loginSalesforce() {

--- a/PHC-Android/PHC/src/main/res/drawable-hdpi/disabled_button.xml
+++ b/PHC-Android/PHC/src/main/res/drawable-hdpi/disabled_button.xml
@@ -4,7 +4,7 @@
     <item>
         <shape>
             <solid
-                android:color="@color/white" />
+                android:color="@android:color/white" />
             <stroke
                 android:width="1dp"
                 android:color="@color/gray" />

--- a/PHC-Android/PHC/src/main/res/drawable-hdpi/enabled_button.xml
+++ b/PHC-Android/PHC/src/main/res/drawable-hdpi/enabled_button.xml
@@ -22,7 +22,7 @@
     <item>
         <shape>
             <solid
-                android:color="@color/white" />
+                android:color="@android:color/white" />
             <stroke
                 android:width="1dp"
                 android:color="@color/red" />

--- a/PHC-Android/PHC/src/main/res/layout/activity_main.xml
+++ b/PHC-Android/PHC/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
 
     <Button
         android:id="@+id/button_services"
-        android:background="@drawable/enabled_button"
+        android:background="@drawable/disabled_button"
         android:text="@string/button_services"
         android:layout_width="300dp"
         android:layout_height="50dp"
@@ -21,7 +21,7 @@
 
     <Button
         android:id="@+id/button_register"
-        android:background="@drawable/enabled_button"
+        android:background="@drawable/disabled_button"
         android:text="@string/button_login"
         android:layout_width="300dp"
         android:layout_height="50dp"
@@ -31,7 +31,7 @@
 
     <Button
         android:id="@+id/button_exit"
-        android:background="@drawable/enabled_button"
+        android:background="@drawable/disabled_button"
         android:text="@string/button_logout"
         android:layout_width="300dp"
         android:layout_height="50dp"

--- a/PHC-Android/PHC/src/main/res/values/colors.xml
+++ b/PHC-Android/PHC/src/main/res/values/colors.xml
@@ -2,7 +2,6 @@
 <resources>
 
     <item name="red" type="color">#FFD64541</item>
-    <item name="black" type="color">#00000000</item>
     <item name="white" type="color">#FFFFFFFF</item>
     <item name="gray" type="color">#FFC0C0C0</item>
 

--- a/PHC-Android/PHC/src/main/res/values/colors.xml
+++ b/PHC-Android/PHC/src/main/res/values/colors.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <item name="red" type="color">#FFD64541</item>
-    <item name="white" type="color">#FFFFFFFF</item>
-    <item name="gray" type="color">#FFC0C0C0</item>
+    <item name="red" type="color">#D64541</item>
+    <item name="gray" type="color">#C0C0C0</item>
 
-    <item name="red_actionbar" type="color">#FFD64541</item>
-    <item name="red_sidebar" type="color">#FFFFE9E9</item>
-    <item name="gray_sidebar" type="color">#FFC0C0C0</item>
-    <item name="button_text_color" type="color">#FF444444</item>
-    <item name="hint_color" type="color">#FF888888</item>
-    <item name="text_color" type="color">#FF444444</item>
+    <item name="red_actionbar" type="color">#D64541</item>
+    <item name="red_sidebar" type="color">#FFE9E9</item>
+    <item name="gray_sidebar" type="color">#C0C0C0</item>
+    <item name="button_text_color" type="color">#444444</item>
+    <item name="hint_color" type="color">#888888</item>
+    <item name="text_color" type="color">#444444</item>
 
 </resources>

--- a/PHC-Android/PHC/src/main/res/values/strings.xml
+++ b/PHC-Android/PHC/src/main/res/values/strings.xml
@@ -51,8 +51,8 @@
 
     <!-- Splash Page -->
     <string name="button_services">Services</string>
-    <string name="button_login">Login</string>
-    <string name="button_logout">Logout</string>
+    <string name="button_login">Check-In</string>
+    <string name="button_logout">Check-Out</string>
     <string name="title_activity_register">Register Client</string>
     <string name="title_activity_services">Manage Services</string>
     <string name="title_activity_exit">Exit Form</string>

--- a/PHC-Android/PHC/src/main/res/values/styles.xml
+++ b/PHC-Android/PHC/src/main/res/values/styles.xml
@@ -72,7 +72,7 @@
 
     <style name="EnabledButtonText">
         <item name="android:textSize">20sp</item>
-        <item name="android:textColor">@color/black</item>
+        <item name="android:textColor">@android:color/black</item>
     </style>
 
     <style name="DisabledButtonText">


### PR DESCRIPTION
Made following changes to @warrenshen 's code:
(don't worry warren, this won't happen again! i'm only doing it this time because there's no time for you to fix them yourself. also, I wasn't aware of these issues myself.)
1. with temporary salesforce integration back, I restored the disabled-to-enabled functionality of the main buttons.
2. Tony and I removed the "alpha" (first two values) on the hexadecimal colors in colors.xml. These two values adjust the transparency of the color (00 being completely transparent to FF being completely opaque. Because "black" was set to "00000000", we couldn't see it. The better standard is to leave out the first two letters altogether and simply adjust the alpha/transparency levels in the code. 
3. We also removed "white" and "black" completely in colors.xml because they are already defined in the standard android color set.
4. I've changed the string names from "login" and "logout" to "checkin" and "checkout" to maintain more consistency with shimmy's code for now. I also just remembered that Kate said that she'd prefer those two names over login and logout because login and logout might mislead volunteers into thinking it means logging into/out of salesforce or rails server. I'll ask her again tomorrow. 